### PR TITLE
feat: include structured fields in journald MESSAGE output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 
 Cargo.lock
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "kamu-logging"
 publish = true
 readme = "README.md"
 repository = "https://github.com/pt-immer/kamu-logging"
-version = "0.1.3"
+version = "0.1.4"
 
 [features]
 default = ["systemd", "with-actix-web"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ compile_error!("Feature \"with-actix-web\" can't be combined with \"wasm32\".");
 #[cfg(not(any(feature = "systemd", feature = "wasm32")))]
 compile_error!("At least feature \"systemd\" or \"wasm32\" must be enabled.");
 
+/// basic re-exports
+pub use tracing::{debug, error, info, trace, warn};
+
 #[cfg(all(debug_assertions, feature = "systemd"))]
 const TRACING_FILTER: &str = "debug";
 #[cfg(all(not(debug_assertions), feature = "systemd"))]
@@ -70,12 +73,11 @@ fn init_systemd() -> std::result::Result<(), Error> {
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
             .with_writer(std::io::stderr);
-        let subscriber_with_journald = tracing_subscriber::layer::SubscriberExt::with(
-            subscriber,
-            journald_layer,
-        );
+        let subscriber_with_journald =
+            tracing_subscriber::layer::SubscriberExt::with(subscriber, journald_layer);
         tracing::subscriber::set_global_default(tracing_subscriber::layer::SubscriberExt::with(
-            subscriber_with_journald, fmt_layer,
+            subscriber_with_journald,
+            fmt_layer,
         ))?;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,15 @@ fn init_systemd() -> std::result::Result<(), Error> {
         ))?;
     } else {
         let journald_layer = tracing_journald::layer()?;
-        tracing::subscriber::set_global_default(tracing_subscriber::layer::SubscriberExt::with(
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(std::io::stderr);
+        let subscriber_with_journald = tracing_subscriber::layer::SubscriberExt::with(
             subscriber,
             journald_layer,
+        );
+        tracing::subscriber::set_global_default(tracing_subscriber::layer::SubscriberExt::with(
+            subscriber_with_journald, fmt_layer,
         ))?;
     }
 


### PR DESCRIPTION
### Description
Currently, when running as a systemd service, `tracing-journald` only stores fields as structured data. While this works for `journalctl -o json`, the fields are lost in the default text view and when exporting logs via stdout/stderr, making it difficult to trace historical logs.

### Changes
- Added a `fmt::layer()` with `with_ansi(false)` when running in non-terminal (systemd) environments.
- This ensures that structured fields are merged into the `MESSAGE` field, improving log readability in standard `journalctl` output and log exports.

### Benefit
Developers no longer need to manually duplicate fields into the format string:
- Before: `info!(field = %val, "message: {}", val)`
- After: `info!(field = %val, "message")`