### PR TITLE
feat: cli usability improvements

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,15 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  md-lint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v17
+        with:
+          globs: '**/*.md'
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # Non-wasm CI feature bundle. `--all-features` clashes with the
-  # systemd <-> wasm32 compile_error invariant.
+  # systemd <-> wasm32 compile_error invariant. Kept in sync with the
+  # `ci_features` variable in the Justfile.
   CI_FEATURES: systemd,with-actix-web,with-otlp
 
 jobs:
@@ -28,18 +29,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just fmt-check
 
-  md-lint:
+  lint-md:
     name: markdownlint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v17
+      - uses: taiki-e/install-action@v2
         with:
-          globs: '**/*.md'
+          tool: just
+      - run: just lint-md
 
-  clippy:
+  lint-rs:
     name: clippy
     runs-on: ubuntu-latest
     needs: fmt
@@ -50,10 +55,10 @@ jobs:
           components: clippy
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: clippy (full feature bundle)
-        run: cargo clippy --all-targets --features ${{ env.CI_FEATURES }} -- -D warnings
-      - name: clippy (wasm32)
-        run: cargo clippy --no-default-features --features wasm32 --target wasm32-unknown-unknown -- -D warnings
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just lint-rs
 
   test:
     name: test (${{ matrix.profile }})
@@ -62,18 +67,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - profile: default
-            args: ""
-          - profile: systemd-only
-            args: "--no-default-features --features systemd"
-          - profile: full
-            args: "--features systemd,with-actix-web,with-otlp"
+        profile: [default, systemd, all]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test ${{ matrix.args }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - name: just test (default)
+        if: matrix.profile == 'default'
+        run: just test
+      - name: just test-systemd
+        if: matrix.profile == 'systemd'
+        run: just test-systemd
+      - name: just test-all
+        if: matrix.profile == 'all'
+        run: just test-all
 
   build-wasm:
     name: build wasm32
@@ -85,7 +95,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --no-default-features --features wasm32 --target wasm32-unknown-unknown
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just build-wasm
 
   msrv:
     name: MSRV (1.85)
@@ -95,6 +108,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
+      # MSRV job pre-activates Rust 1.85 via dtolnay action, so call cargo
+      # directly (the `just msrv` recipe re-activates via `rustup run`).
       - name: check (default)
         run: cargo check
       - name: check (full feature bundle)
@@ -104,13 +119,14 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     needs: fmt
-    env:
-      RUSTDOCFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --no-deps --features ${{ env.CI_FEATURES }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just doc-check
 
   coverage:
     name: coverage
@@ -123,12 +139,12 @@ jobs:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov,just
       - uses: Swatinem/rust-cache@v2
-      - name: cargo llvm-cov (lcov)
-        run: cargo llvm-cov --features ${{ env.CI_FEATURES }} --lcov --output-path lcov.info
-      - name: cargo llvm-cov (summary)
-        run: cargo llvm-cov report --features ${{ env.CI_FEATURES }} --summary-only | tee coverage-summary.txt
+      - name: just coverage-lcov
+        run: just coverage-lcov
+      - name: just coverage (summary)
+        run: just coverage | tee coverage-summary.txt
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -152,10 +168,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-audit
+          tool: cargo-audit,just
       # Cargo.lock is gitignored (library convention) - generate before audit.
       - run: cargo generate-lockfile
-      - run: cargo audit --deny warnings
+      - run: just audit
 
   deny:
     name: cargo deny
@@ -167,8 +183,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny
-      - run: cargo deny check
+          tool: cargo-deny,just
+      - run: just deny
 
   semver:
     name: semver-checks
@@ -180,4 +196,3 @@ jobs:
         with:
           feature-group: only-explicit-features
           features: systemd,with-actix-web,with-otlp
-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,174 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Non-wasm CI feature bundle. `--all-features` clashes with the
+  # systemd <-> wasm32 compile_error invariant.
+  CI_FEATURES: systemd,with-actix-web,with-otlp
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: clippy (full feature bundle)
+        run: cargo clippy --all-targets --features ${{ env.CI_FEATURES }} -- -D warnings
+      - name: clippy (wasm32)
+        run: cargo clippy --no-default-features --features wasm32 --target wasm32-unknown-unknown -- -D warnings
+
+  test:
+    name: test (${{ matrix.profile }})
+    runs-on: ubuntu-latest
+    needs: fmt
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: default
+            args: ""
+          - profile: systemd-only
+            args: "--no-default-features --features systemd"
+          - profile: full
+            args: "--features systemd,with-actix-web,with-otlp"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test ${{ matrix.args }}
+
+  build-wasm:
+    name: build wasm32
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --no-default-features --features wasm32 --target wasm32-unknown-unknown
+
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+      - name: check (default)
+        run: cargo check
+      - name: check (full feature bundle)
+        run: cargo check --features ${{ env.CI_FEATURES }}
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    needs: fmt
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps --features ${{ env.CI_FEATURES }}
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo llvm-cov (lcov)
+        run: cargo llvm-cov --features ${{ env.CI_FEATURES }} --lcov --output-path lcov.info
+      - name: cargo llvm-cov (summary)
+        run: cargo llvm-cov report --features ${{ env.CI_FEATURES }} --summary-only | tee coverage-summary.txt
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: false
+      - name: Upload lcov artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: |
+            lcov.info
+            coverage-summary.txt
+
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      # Cargo.lock is gitignored (library convention) - generate before audit.
+      - run: cargo generate-lockfile
+      - run: cargo audit --deny warnings
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    needs: fmt
+    if: hashFiles('deny.toml') != ''
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check
+
+  semver:
+    name: semver-checks
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: only-explicit-features
+          features: systemd,with-actix-web,with-otlp
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,10 @@ jobs:
         run: cargo build --features with-otlp
 
       - name: Test
-        run: cargo test --all-features
+        run: cargo test --features systemd,with-actix-web,with-otlp
 
       - name: Doc build
-        run: cargo doc --no-deps --all-features
+        run: cargo doc --no-deps --features systemd,with-actix-web,with-otlp
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry + build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Assert tag matches Cargo.toml version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          manifest=$(grep -m1 '^version' Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
+          if [ "$tag" != "$manifest" ]; then
+            echo "Release tag ($tag) does not match Cargo.toml version ($manifest)" >&2
+            exit 1
+          fi
+
+      - name: Build (default features)
+        run: cargo build
+
+      - name: Build (systemd only)
+        run: cargo build --no-default-features --features systemd
+
+      - name: Build (wasm32 target)
+        run: cargo build --no-default-features --features wasm32 --target wasm32-unknown-unknown
+
+      - name: Build (with-otlp)
+        run: cargo build --features with-otlp
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Doc build
+        run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  publish:
+    name: Publish
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + build
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,21 @@
+config:
+  default: true
+  # Disable hard line-length rule; prose wrapping is editor-dependent.
+  MD013: false
+  # CHANGELOG.md repeats "### Added" / "### Changed" under each release.
+  MD024:
+    siblings_only: true
+  # Allow inline HTML (occasional <br>, <details> in README/CHANGELOG).
+  MD033: false
+  # Don't require the first line to be a top-level heading.
+  MD041: false
+  # Don't require table pipes to align - long descriptions make it painful.
+  MD060: false
+
+globs:
+  - "**/*.md"
+
+ignores:
+  - "target/**"
+  - "node_modules/**"
+  - ".github/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to this project are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows
+[SemVer](https://semver.org/) from `1.0.0` onwards.
+
+## [1.0.0] — 2026-05-27
+
+First stable release. Single breaking-change release that turns the crate
+from a thin `tracing-subscriber` wrapper into the canonical PT IMMER
+logging primitive.
+
+### Added
+
+- `InitOptions` builder + `init_with(opts)` for explicit configuration.
+- `Format` enum (`Auto`, `Compact`, `Pretty`, `Json`) — JSON output for
+  log aggregators (Vector, Promtail, Datadog, Fluent Bit).
+- `Sink` enum (`Auto`, `Stdout`, `Stderr`, `Journald`) — explicit
+  sink selection with `Auto` preserving previous TTY-aware behavior.
+- Env-var triggers `KAMU_LOG_FORMAT` and `KAMU_LOG_SINK` for zero-code
+  adoption.
+- `init_or_skip()` shortcut and `InitOptions::idempotent(true)` for test
+  harnesses and embedded CLI runs.
+- `with_service_name`, `with_default_filter`, `with_env_var` builder
+  methods for service tagging and per-binary log env vars.
+- `correlation` module: `extract_from_headers`, `parse_traceparent_trace_id`,
+  `with_id`, `span` helpers. Default header chain: `X-Request-ID`,
+  `X-Correlation-ID`, `traceparent`.
+- `EnrichedRootSpanBuilder` for `tracing-actix-web` — adds
+  `correlation_id` to the root span automatically.
+- `get_actix_web_logger_with::<RSB>()` for custom `RootSpanBuilder`
+  implementations.
+- `with-otlp` feature (`opentelemetry` 0.32, `opentelemetry-otlp` 0.32,
+  `tracing-opentelemetry` 0.33) with `OtlpConfig` builder.
+- Wider `tracing` re-exports: `Level`, `Span`, `enabled`, `event`,
+  `instrument`, `span`, in addition to existing macros.
+- Integration tests (`tests/init_*.rs`, `tests/correlation.rs`) and
+  examples (`examples/{minimal,json_stdout,actix}.rs`).
+- `CHANGELOG.md` and `rust-version = "1.85"` declared in Cargo.toml.
+- `#[non_exhaustive]` on `Error` so future variants are non-breaking.
+- `compile_error!` invariant added for `with-otlp` + `wasm32` clash.
+- `#[deny(missing_docs)]` on the crate root; all public items documented.
+
+### Changed
+
+- **Breaking**: `init()` now returns `Err(Error::AlreadyInitialized)` on
+  a second call instead of `Err(TracingGlobal(_))`. Migration: callers
+  matching on `TracingGlobal` for duplicate-init detection should match
+  `AlreadyInitialized` instead, or switch to `init_or_skip()`.
+- **Breaking**: `get_actix_web_logger()` now returns
+  `TracingLogger<EnrichedRootSpanBuilder>` instead of
+  `TracingLogger<DefaultRootSpanBuilder>`. Adds a `correlation_id`
+  field; spans previously dependent on `DefaultRootSpanBuilder`'s exact
+  shape may need updating. To opt out, use
+  `get_actix_web_logger_with::<DefaultRootSpanBuilder>()`.
+- **Breaking**: `Error` is now `#[non_exhaustive]`. Exhaustive `match`
+  statements over `Error` will need a wildcard arm.
+- README rewritten for the v1 API — feature matrix, env-var triggers,
+  troubleshooting table, SemVer policy.
+- Edition stays at `2024`; `rust-version = "1.85"` declared explicitly.
+
+### Preserved (not changed)
+
+- `init()` zero-arg form still works (delegates to
+  `init_with(InitOptions::default())`).
+- TTY-aware default behavior (`Sink::Auto` + `Format::Auto`) matches
+  prior versions.
+- `tracing_log::LogTracer` bridge still installed on the systemd path.
+- `compile_error!` invariants for `systemd` + `wasm32` and
+  `with-actix-web` + `wasm32` remain.
+- `wasm32` `OnceLock`-gated idempotence behavior unchanged.
+
+## [0.2.0] — 2026-05
+
+- Use journald as sole non-TTY sink (no stderr fallback). (#4)
+- Include structured fields in journald `MESSAGE` output. (#3)
+
+## [0.1.3] — 2026
+
+- Cloudflare Workers compatibility. (#2)
+- Initial wasm32 feature.
+
+## [0.1.0] — initial release
+
+- Initial public surface: `init()`, `get_actix_web_logger()`, macro re-exports.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,23 @@ name = "kamu-logging"
 publish = true
 readme = "README.md"
 repository = "https://github.com/pt-immer/kamu-logging"
-version = "0.2.0"
+rust-version = "1.85"
+version = "1.0.0"
 
 [features]
 default = ["systemd", "with-actix-web"]
 systemd = ["dep:console", "dep:tracing-journald", "dep:tracing-log", "dep:tracing-subscriber"]
 wasm32 = ["dep:console_error_panic_hook", "dep:tracing-subscriber", "dep:wasm-tracing"]
-with-actix-web = ["dep:tracing-actix-web"]
+with-actix-web = ["dep:actix-web", "dep:tracing-actix-web"]
+with-otlp = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+]
 
 [dependencies]
+actix-web = { version = "4", optional = true, default-features = false }
 console = { version = "~0.16", optional = true }
 console_error_panic_hook = { version = "~0.1.7", optional = true }
 thiserror = "~2"
@@ -27,6 +35,11 @@ tracing-actix-web = { version = "~0.7", optional = true }
 tracing-journald = { version = "~0.3", optional = true }
 tracing-log = { version = "~0.2", optional = true }
 wasm-tracing = { version = "~2.1.0", features = ["tracing-log"], optional = true }
+
+opentelemetry = { version = "~0.32", optional = true, default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "~0.32", optional = true, default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "~0.32", optional = true, default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+tracing-opentelemetry = { version = "~0.33", optional = true, default-features = false, features = ["tracing-log"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tracing-subscriber = { version = "~0.3", optional = true, features = [
@@ -46,3 +59,19 @@ tracing-subscriber = { version = "~0.3", optional = true, default-features = fal
     "alloc",
     "fmt",
 ] }
+
+[dev-dependencies]
+actix-web = "4"
+
+[[example]]
+name = "minimal"
+required-features = ["systemd"]
+
+[[example]]
+name = "json_stdout"
+required-features = ["systemd"]
+
+[[example]]
+name = "actix"
+required-features = ["systemd", "with-actix-web"]
+

--- a/README.md
+++ b/README.md
@@ -1,59 +1,202 @@
-# kamu‑logging
+# kamu-logging
 
-`kamu‑logging` is a small helper crate to configure structured logging for
-services built by PT IMMER.  It wraps the [`tracing`](https://docs.rs/tracing)
-ecosystem and selects an appropriate backend depending on your target
-platform.
+Opinionated `tracing` setup for PT IMMER services. One-line init for the
+zero-config path; a builder for everything else (JSON output, custom env
+vars, OTLP export, correlation ids).
 
-## Supported targets
-
-* **Systemd (default)** – When the `systemd` feature is enabled, the crate
-  initialises a `tracing` subscriber that forwards logs from the `log` crate,
-  parses the `RUST_LOG` environment variable, and emits either coloured
-  console output or forwards events to journald when not attached to a TTY.
-
-* **WASM (`wasm32` feature)** – On WebAssembly targets the crate installs
-  [`console_error_panic_hook`](https://docs.rs/console_error_panic_hook)
-  to improve panic messages and configures the [`wasm‑tracing`](https://github.com/dsgallups/wasm-tracing)
-  subscriber.
-
-* **Actix Web (`with-actix-web` feature)** – Exposes a
-  `get_actix_web_logger()` function returning an Actix Web middleware
-  logger.
-
-## Usage
-
-Add the crate to your `Cargo.toml` and call `kamu_logging::init()` early
-in `main`.  At least one of the mutually exclusive `systemd` or
-`wasm32` features must be enabled.  The `systemd` feature is enabled by
-default.
+## Install
 
 ```toml
 [dependencies]
-kamu‑logging = "0.1.3"
+kamu-logging = "1"
 ```
+
+MSRV: **Rust 1.85** (edition 2024).
+
+## Features
+
+| Feature          | Default | What it enables                                                       |
+|------------------|:-------:|-----------------------------------------------------------------------|
+| `systemd`        |   yes   | TTY-aware console + journald sink, `RUST_LOG`, `log` → `tracing` bridge |
+| `with-actix-web` |   yes   | Correlation-enriched Actix Web middleware                              |
+| `with-otlp`      |   no    | OpenTelemetry OTLP exporter (HTTP/protobuf)                           |
+| `wasm32`         |   no    | Browser console + panic hook (mutually exclusive with the others)     |
+
+## Quickstart
 
 ```rust
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialise logging.  This will forward any logs emitted via the
-    // `log` crate into the `tracing` subscriber and pick the
-    // appropriate backend.
     kamu_logging::init()?;
-
-    // Your application logic here.
+    kamu_logging::info!("hello");
     Ok(())
 }
 ```
 
-When building for `wasm32` targets, enable the `wasm32` feature and
-disable the default features:
+`init()` picks a sensible default for the target: pretty TTY output when
+stdout is a terminal, journald when not, and `RUST_LOG` for filtering.
+
+## Configuration
+
+For anything beyond the default path, build an `InitOptions`:
+
+```rust
+use kamu_logging::{Format, InitOptions, Sink, init_with};
+
+init_with(
+    InitOptions::default()
+        .with_service_name("my-service")
+        .with_default_filter("info,my_service=debug")
+        .with_env_var("MY_SERVICE_LOG")
+        .with_format(Format::Json)
+        .with_sink(Sink::Stdout),
+)?;
+```
+
+Builder methods (all consume `self`, all return `Self`):
+
+| Method                   | Purpose                                                            |
+|--------------------------|--------------------------------------------------------------------|
+| `with_service_name(n)`   | Attach `service.name` to the startup event + OTLP `Resource`       |
+| `with_default_filter(f)` | Filter directive used when the env var is unset                    |
+| `with_env_var(v)`        | Env var read for the filter (default `RUST_LOG`)                   |
+| `with_format(f)`         | `Auto` / `Compact` / `Pretty` / `Json`                             |
+| `with_sink(s)`           | `Auto` / `Stdout` / `Stderr` / `Journald`                          |
+| `idempotent(true)`       | Treat duplicate init as `Ok(())` (test harnesses, embedded runs)   |
+| `with_otlp(cfg)`         | (with-otlp) Add an OTLP exporter layer                             |
+
+### Env-var triggers (no code change)
+
+| Variable           | Values                                  | Effect                                  |
+|--------------------|-----------------------------------------|-----------------------------------------|
+| `RUST_LOG`         | tracing-subscriber directive            | Filter directive (overridable per init) |
+| `KAMU_LOG_FORMAT`  | `auto`, `compact`, `pretty`, `json`     | Sets `Format` when the option is `Auto` |
+| `KAMU_LOG_SINK`    | `auto`, `stdout`, `stderr`, `journald`  | Sets `Sink` when the option is `Auto`   |
+
+## JSON output for log aggregators
+
+```rust
+use kamu_logging::{Format, InitOptions, Sink, init_with};
+
+init_with(
+    InitOptions::default()
+        .with_format(Format::Json)
+        .with_sink(Sink::Stdout),
+)?;
+```
+
+Or set `KAMU_LOG_FORMAT=json KAMU_LOG_SINK=stdout` at the process level
+for zero-code adoption. Each event is one line of JSON suitable for
+Vector, Promtail, Fluent Bit, or the Datadog Agent.
+
+## Actix Web
+
+```rust
+use actix_web::{App, HttpServer};
+use kamu_logging::get_actix_web_logger;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    kamu_logging::init().expect("init logging");
+    HttpServer::new(|| App::new().wrap(get_actix_web_logger()))
+        .bind(("127.0.0.1", 8080))?
+        .run()
+        .await
+}
+```
+
+`get_actix_web_logger()` uses an `EnrichedRootSpanBuilder` that adds a
+`correlation_id` field to the root span by extracting (in order):
+`X-Request-ID`, `X-Correlation-ID`, `traceparent`. For a custom builder,
+use `get_actix_web_logger_with::<MyBuilder>()`.
+
+## Correlation outside HTTP
+
+For queue consumers, scheduled tasks, or any non-HTTP entry point:
+
+```rust
+use kamu_logging::correlation::{with_id, extract_from_headers, DEFAULT_HEADER_CHAIN};
+
+with_id("job-42", || {
+    kamu_logging::info!("processing job");
+});
+```
+
+The header-chain extractor is reusable for any framework — pass a closure
+that fetches a header by name:
+
+```rust
+let id = extract_from_headers(&headers, DEFAULT_HEADER_CHAIN, |h, name| {
+    h.get(name).cloned()
+});
+```
+
+## OTLP export
+
+Enable the `with-otlp` feature and attach an `OtlpConfig`:
+
+```rust
+use kamu_logging::{InitOptions, init_with, otlp::OtlpConfig};
+
+init_with(
+    InitOptions::default()
+        .with_service_name("checkout-api")
+        .with_otlp(
+            OtlpConfig::new("https://otel-collector.example.com:4318")
+                .with_service_name("checkout-api")
+                .with_header("authorization", "Bearer …")
+                .with_resource_attribute("deployment.environment", "production"),
+        ),
+)?;
+```
+
+Uses a synchronous `SimpleSpanProcessor` so no async runtime is required.
+High-throughput services should replace the exporter with a batch
+processor configured against their runtime — open an issue if you want a
+built-in option.
+
+## WASM
 
 ```toml
 [dependencies]
-kamu‑logging = { version = "0.1.3", default‑features = false, features = ["wasm32"] }
+kamu-logging = { version = "1", default-features = false, features = ["wasm32"] }
 ```
+
+`init()` on wasm32 installs `console_error_panic_hook` and the
+`wasm-tracing` subscriber. The function is idempotent on this target by
+design; subsequent calls are no-ops.
+
+## Idempotence
+
+- `init()` returns `Err(Error::AlreadyInitialized)` on a second call.
+  Surfaces library double-init as a bug.
+- `init_or_skip()` returns `Ok(())` on a second call. Use from test
+  harnesses and embedded CLI runs.
+- `InitOptions::idempotent(true)` does the same thing via the builder.
+
+## Re-exported `tracing` items
+
+So you can avoid a separate `tracing` import for the basics:
+
+```rust
+use kamu_logging::{debug, info, warn, error, instrument, span, Level, Span};
+```
+
+## Troubleshooting
+
+| Symptom                                        | Fix                                                                    |
+|------------------------------------------------|------------------------------------------------------------------------|
+| No logs in container                           | Set `KAMU_LOG_SINK=stdout` — default routes non-TTY to journald        |
+| `Error::IO` at init in a container             | journald socket unavailable; use `KAMU_LOG_SINK=stdout`                |
+| Tests hang at `init()`                         | Use `init_or_skip()` per-test or `InitOptions::idempotent(true)`        |
+| OTLP exporter slow                             | `SimpleSpanProcessor` is synchronous; high-volume needs a batch processor |
+| `service.name` missing from fmt output         | Only attached to startup event + OTLP Resource; aggregators add it from infra metadata |
+
+## SemVer policy
+
+`1.x.y` — breaking changes only on major bumps. Additive changes ship as
+minor releases. Bug fixes ship as patches. The `Error` enum is
+`#[non_exhaustive]`; new variants are not breaking.
 
 ## License
 
-This project is licensed under the MIT License.  See the [LICENSE](LICENSE)
-file for details.
+MIT — see [LICENSE](LICENSE).

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -1,0 +1,23 @@
+//! Actix Web example with correlation-enriched root spans.
+//!
+//! Run with `cargo run --example actix --features with-actix-web` then
+//! `curl -H "X-Request-ID: req-abc123" http://127.0.0.1:8080/`. Logs will
+//! include `correlation_id=req-abc123` on the root span.
+
+use actix_web::{App, HttpResponse, HttpServer, Responder, get};
+use kamu_logging::{get_actix_web_logger, info, init};
+
+#[get("/")]
+async fn index() -> impl Responder {
+    info!("serving /");
+    HttpResponse::Ok().body("hello\n")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    init().expect("init logging");
+    HttpServer::new(|| App::new().wrap(get_actix_web_logger()).service(index))
+        .bind(("127.0.0.1", 8080))?
+        .run()
+        .await
+}

--- a/examples/json_stdout.rs
+++ b/examples/json_stdout.rs
@@ -1,0 +1,18 @@
+//! JSON-on-stdout example for log aggregators (Vector, Promtail, Datadog).
+//!
+//! Run with `cargo run --example json_stdout | jq .`. Pipe-friendly:
+//! every event is one line of JSON.
+
+use kamu_logging::{Format, InitOptions, Sink, info, init_with};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_with(
+        InitOptions::default()
+            .with_service_name("json-stdout-example")
+            .with_format(Format::Json)
+            .with_sink(Sink::Stdout),
+    )?;
+    info!(user_id = 12345, "user signed in");
+    info!(order_id = "ORD-789", total_cents = 19_900, "order placed");
+    Ok(())
+}

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,0 +1,13 @@
+//! Minimal example: zero-config init.
+//!
+//! Run with `cargo run --example minimal`. Set `RUST_LOG=debug` to see the
+//! debug event.
+
+use kamu_logging::{debug, info, init};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init()?;
+    info!("hello from kamu-logging");
+    debug!(value = 42, "structured field example");
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
-# kamu-logging dev tasks. Run `just` (no args) to list. Run `just verify`
-# locally to mirror what the PR gate runs.
+# kamu-logging dev tasks. Run `just` (no args) to list. Run `just gate-all`
+# locally to mirror the PR gate.
 
 # Non-wasm feature bundle. `--all-features` clashes with the
 # systemd <-> wasm32 compile_error invariant; CI uses this exact string.
@@ -9,6 +9,32 @@ msrv := "1.85"
 # Show the task list.
 default:
     @just --list --unsorted
+
+# --- Setup ----------------------------------------------------------------
+
+# Install every dev tool `just gate-slow` expects.
+setup:
+    cargo install cargo-audit cargo-llvm-cov cargo-semver-checks
+    rustup component add llvm-tools-preview
+    rustup toolchain install {{msrv}}
+    @echo "Optional: install cargo-deny if you maintain a deny.toml."
+
+# Diagnose which dev tools are present on this machine.
+doctor:
+    @echo "=== Toolchain ==="
+    @command -v cargo >/dev/null && echo "[ok]      cargo ($(cargo --version | cut -d' ' -f2))" || echo "[missing] cargo"
+    @rustup toolchain list 2>/dev/null | grep -q '^{{msrv}}' && echo "[ok]      rust {{msrv}} (MSRV)" || echo "[missing] rust {{msrv}}    (run: just setup)"
+    @rustup component list --installed 2>/dev/null | grep -q llvm-tools-preview && echo "[ok]      llvm-tools-preview" || echo "[missing] llvm-tools-preview (run: just setup)"
+    @echo
+    @echo "=== Cargo extensions ==="
+    @command -v cargo-audit >/dev/null && echo "[ok]      cargo-audit" || echo "[missing] cargo-audit         (run: just setup)"
+    @command -v cargo-llvm-cov >/dev/null && echo "[ok]      cargo-llvm-cov" || echo "[missing] cargo-llvm-cov      (run: just setup)"
+    @command -v cargo-semver-checks >/dev/null && echo "[ok]      cargo-semver-checks" || echo "[missing] cargo-semver-checks (run: just setup)"
+    @command -v cargo-deny >/dev/null && echo "[ok]      cargo-deny" || echo "[note]    cargo-deny          (optional)"
+    @echo
+    @echo "=== External ==="
+    @command -v just >/dev/null && echo "[ok]      just" || echo "[missing] just"
+    @command -v npx >/dev/null && echo "[ok]      npx (markdownlint runner)" || echo "[missing] npx (Node.js needed for lint-md)"
 
 # --- Build ----------------------------------------------------------------
 
@@ -24,7 +50,7 @@ build-all:
 build-wasm:
     cargo build --no-default-features --features wasm32 --target wasm32-unknown-unknown
 
-# Build everything (default + systemd-only + wasm32 + with-otlp).
+# Build every supported profile (default + systemd-only + wasm32 + with-otlp).
 build-matrix: build
     cargo build --no-default-features --features systemd
     just build-wasm
@@ -40,35 +66,42 @@ test:
 test-all:
     cargo test --features {{ci_features}}
 
+# Run tests with systemd only (no actix-web, no otlp).
+test-systemd:
+    cargo test --no-default-features --features systemd
+
 # --- Format ---------------------------------------------------------------
 
 # Apply rustfmt across the tree.
-fmt:
+fmt-all:
     cargo fmt --all
 
 # Verify rustfmt cleanliness (PR gate).
 fmt-check:
     cargo fmt --all --check
 
+# Apply markdownlint auto-fix where possible.
+fmt-md:
+    npx --yes markdownlint-cli2 --fix
+
 # --- Lint -----------------------------------------------------------------
 
+# Run every linter (Rust + Markdown).
+lint-all: lint-rs lint-md
+
 # Clippy across the full bundle + wasm32 with -D warnings.
-clippy:
+lint-rs:
     cargo clippy --all-targets --features {{ci_features}} -- -D warnings
     cargo clippy --no-default-features --features wasm32 --target wasm32-unknown-unknown -- -D warnings
 
-# Markdown lint (requires Node.js / npx).
-md-lint:
+# Run markdownlint (requires Node.js / npx).
+lint-md:
     npx --yes markdownlint-cli2
-
-# Markdown lint with auto-fix where possible.
-md-fix:
-    npx --yes markdownlint-cli2 --fix
 
 # --- Docs -----------------------------------------------------------------
 
 # Build docs locally and open in browser.
-doc:
+doc-open:
     cargo doc --no-deps --features {{ci_features}} --open
 
 # Build docs treating warnings as errors (PR gate).
@@ -132,17 +165,10 @@ tag VERSION:
 
 # --- Aggregates ---------------------------------------------------------
 
-# Run every check that the PR gate runs, in CI order. Mirrors pr.yml.
-verify: fmt-check clippy test-all build-wasm doc-check md-lint audit
+# Run every check that the PR gate runs. Mirrors pr.yml.
+gate-all: fmt-check lint-all test-all build-wasm doc-check audit
     @echo "All PR gates passed locally."
 
-# Like verify, plus the slow checks (coverage + semver + msrv).
-verify-full: verify coverage semver msrv
-    @echo "All PR + nightly-style gates passed locally."
-
-# Install all the tooling `just verify-full` needs.
-install-tools:
-    cargo install cargo-audit cargo-llvm-cov cargo-semver-checks
-    rustup component add llvm-tools-preview
-    rustup toolchain install {{msrv}}
-    @echo "Don't forget: deny.toml is optional; install cargo-deny if you use it."
+# Like gate-all, plus the slow checks (coverage + semver + msrv).
+gate-slow: gate-all coverage semver msrv
+    @echo "All PR + slow gates passed locally."

--- a/justfile
+++ b/justfile
@@ -1,0 +1,148 @@
+# kamu-logging dev tasks. Run `just` (no args) to list. Run `just verify`
+# locally to mirror what the PR gate runs.
+
+# Non-wasm feature bundle. `--all-features` clashes with the
+# systemd <-> wasm32 compile_error invariant; CI uses this exact string.
+ci_features := "systemd,with-actix-web,with-otlp"
+msrv := "1.85"
+
+# Show the task list.
+default:
+    @just --list --unsorted
+
+# --- Build ----------------------------------------------------------------
+
+# Build with default features.
+build:
+    cargo build
+
+# Build with the full non-wasm feature bundle.
+build-all:
+    cargo build --features {{ci_features}}
+
+# Build for wasm32 target.
+build-wasm:
+    cargo build --no-default-features --features wasm32 --target wasm32-unknown-unknown
+
+# Build everything (default + systemd-only + wasm32 + with-otlp).
+build-matrix: build
+    cargo build --no-default-features --features systemd
+    just build-wasm
+    cargo build --features with-otlp
+
+# --- Test -----------------------------------------------------------------
+
+# Run tests with default features.
+test:
+    cargo test
+
+# Run tests with the full non-wasm feature bundle.
+test-all:
+    cargo test --features {{ci_features}}
+
+# --- Format ---------------------------------------------------------------
+
+# Apply rustfmt across the tree.
+fmt:
+    cargo fmt --all
+
+# Verify rustfmt cleanliness (PR gate).
+fmt-check:
+    cargo fmt --all --check
+
+# --- Lint -----------------------------------------------------------------
+
+# Clippy across the full bundle + wasm32 with -D warnings.
+clippy:
+    cargo clippy --all-targets --features {{ci_features}} -- -D warnings
+    cargo clippy --no-default-features --features wasm32 --target wasm32-unknown-unknown -- -D warnings
+
+# Markdown lint (requires Node.js / npx).
+md-lint:
+    npx --yes markdownlint-cli2
+
+# Markdown lint with auto-fix where possible.
+md-fix:
+    npx --yes markdownlint-cli2 --fix
+
+# --- Docs -----------------------------------------------------------------
+
+# Build docs locally and open in browser.
+doc:
+    cargo doc --no-deps --features {{ci_features}} --open
+
+# Build docs treating warnings as errors (PR gate).
+doc-check:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features {{ci_features}}
+
+# --- MSRV -----------------------------------------------------------------
+
+# Check the crate compiles on the declared MSRV (requires `rustup toolchain install {{msrv}}`).
+msrv:
+    rustup run {{msrv}} cargo check
+    rustup run {{msrv}} cargo check --features {{ci_features}}
+
+# --- Security -------------------------------------------------------------
+
+# Run cargo audit (requires `cargo install cargo-audit`).
+audit:
+    cargo audit --deny warnings
+
+# Run cargo deny check (requires `cargo install cargo-deny` and deny.toml).
+deny:
+    cargo deny check
+
+# --- Coverage -------------------------------------------------------------
+
+# Print a coverage summary (requires cargo-llvm-cov + llvm-tools-preview component).
+coverage:
+    cargo llvm-cov --features {{ci_features}} --summary-only
+
+# Generate an HTML coverage report and open it.
+coverage-html:
+    cargo llvm-cov --features {{ci_features}} --html --open
+
+# Generate lcov for upload to Codecov.
+coverage-lcov:
+    cargo llvm-cov --features {{ci_features}} --lcov --output-path lcov.info
+
+# --- Semver --------------------------------------------------------------
+
+# Compare current API against the published crates.io version (requires cargo-semver-checks).
+semver:
+    cargo semver-checks --only-explicit-features --features {{ci_features}}
+
+# --- Examples ------------------------------------------------------------
+
+# Run an example by name. Usage: `just example minimal` or `just example actix`.
+example NAME *ARGS:
+    cargo run --example {{NAME}} --features {{ci_features}} {{ARGS}}
+
+# --- Release ------------------------------------------------------------
+
+# Dry-run cargo publish (validates manifest + builds the package).
+publish-dry:
+    cargo publish --dry-run --allow-dirty
+
+# Tag a release after verifying Cargo.toml matches. Usage: `just tag 1.0.1`.
+tag VERSION:
+    @grep -q '^version = "{{VERSION}}"' Cargo.toml || (echo "Update Cargo.toml version to {{VERSION}} first" >&2 && exit 1)
+    git tag v{{VERSION}}
+    @echo "Tagged v{{VERSION}}. Push with: git push origin v{{VERSION}}"
+
+# --- Aggregates ---------------------------------------------------------
+
+# Run every check that the PR gate runs, in CI order. Mirrors pr.yml.
+verify: fmt-check clippy test-all build-wasm doc-check md-lint audit
+    @echo "All PR gates passed locally."
+
+# Like verify, plus the slow checks (coverage + semver + msrv).
+verify-full: verify coverage semver msrv
+    @echo "All PR + nightly-style gates passed locally."
+
+# Install all the tooling `just verify-full` needs.
+install-tools:
+    cargo install cargo-audit cargo-llvm-cov cargo-semver-checks
+    rustup component add llvm-tools-preview
+    rustup toolchain install {{msrv}}
+    @echo "Don't forget: deny.toml is optional; install cargo-deny if you use it."

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -15,14 +15,12 @@ pub struct EnrichedRootSpanBuilder;
 
 impl RootSpanBuilder for EnrichedRootSpanBuilder {
     fn on_request_start(request: &ServiceRequest) -> Span {
-        let correlation_id = extract_from_headers(request.headers(), DEFAULT_HEADER_CHAIN, |h, n| {
-            h.get(n).and_then(|v| v.to_str().ok()).map(str::to_owned)
-        });
+        let correlation_id =
+            extract_from_headers(request.headers(), DEFAULT_HEADER_CHAIN, |h, n| {
+                h.get(n).and_then(|v| v.to_str().ok()).map(str::to_owned)
+            });
 
-        let span = tracing_actix_web::root_span!(
-            request,
-            correlation_id = tracing::field::Empty
-        );
+        let span = tracing_actix_web::root_span!(request, correlation_id = tracing::field::Empty);
         if let Some(id) = correlation_id {
             span.record("correlation_id", tracing::field::display(&id));
         }

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -1,0 +1,76 @@
+//! Actix Web integration: tracing middleware with correlation enrichment.
+
+use actix_web::body::MessageBody;
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use tracing::Span;
+use tracing_actix_web::{DefaultRootSpanBuilder, RootSpanBuilder, TracingLogger};
+
+use crate::correlation::{DEFAULT_HEADER_CHAIN, extract_from_headers};
+
+/// A [`RootSpanBuilder`] that adds a `correlation_id` field to the root
+/// span when one of [`DEFAULT_HEADER_CHAIN`] is present on the request.
+///
+/// All other span fields match [`DefaultRootSpanBuilder`].
+pub struct EnrichedRootSpanBuilder;
+
+impl RootSpanBuilder for EnrichedRootSpanBuilder {
+    fn on_request_start(request: &ServiceRequest) -> Span {
+        let correlation_id = extract_from_headers(request.headers(), DEFAULT_HEADER_CHAIN, |h, n| {
+            h.get(n).and_then(|v| v.to_str().ok()).map(str::to_owned)
+        });
+
+        let span = tracing_actix_web::root_span!(
+            request,
+            correlation_id = tracing::field::Empty
+        );
+        if let Some(id) = correlation_id {
+            span.record("correlation_id", tracing::field::display(&id));
+        }
+        span
+    }
+
+    fn on_request_end<B: MessageBody>(
+        span: Span,
+        outcome: &Result<ServiceResponse<B>, actix_web::Error>,
+    ) {
+        DefaultRootSpanBuilder::on_request_end(span, outcome);
+    }
+}
+
+/// Construct a [`TracingLogger`] middleware backed by
+/// [`EnrichedRootSpanBuilder`] (the default root span enriched with a
+/// `correlation_id` field).
+///
+/// For a custom [`RootSpanBuilder`], use [`get_actix_web_logger_with`].
+///
+/// ```no_run
+/// use actix_web::{App, HttpServer};
+/// use kamu_logging::get_actix_web_logger;
+///
+/// # async fn run() -> std::io::Result<()> {
+/// HttpServer::new(|| App::new().wrap(get_actix_web_logger()))
+///     .bind("127.0.0.1:8080")?
+///     .run()
+///     .await
+/// # }
+/// ```
+#[must_use]
+pub fn get_actix_web_logger() -> TracingLogger<EnrichedRootSpanBuilder> {
+    TracingLogger::<EnrichedRootSpanBuilder>::new()
+}
+
+/// Construct a [`TracingLogger`] middleware backed by the supplied
+/// [`RootSpanBuilder`]. Use this when the enriched default does not fit
+/// (e.g., to add tenant_id, user_id, or a service-specific field).
+///
+/// ```no_run
+/// use kamu_logging::get_actix_web_logger_with;
+/// use tracing_actix_web::DefaultRootSpanBuilder;
+///
+/// let middleware = get_actix_web_logger_with::<DefaultRootSpanBuilder>();
+/// # let _ = middleware;
+/// ```
+#[must_use]
+pub fn get_actix_web_logger_with<RSB: RootSpanBuilder>() -> TracingLogger<RSB> {
+    TracingLogger::<RSB>::new()
+}

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -1,0 +1,81 @@
+//! Correlation-id helpers for distributed tracing.
+//!
+//! Provides a header-chain extractor and span constructors so consumers
+//! (HTTP middlewares, queue workers) can attach a consistent
+//! `correlation_id` field to every span without re-implementing the
+//! convention per service.
+
+/// Default headers checked, in priority order, by [`extract_from_headers`].
+pub const DEFAULT_HEADER_CHAIN: &[&str] = &["x-request-id", "x-correlation-id", "traceparent"];
+
+/// Extract a correlation id from a header bag using a configurable getter.
+///
+/// `headers` is opaque; the caller supplies `get` which performs the
+/// case-insensitive lookup natural to its header type. `chain` is the
+/// ordered list of header names to try. The first header that yields a
+/// non-empty value wins.
+///
+/// `traceparent` values are reduced to their trace-id segment per W3C
+/// Trace Context (`<version>-<trace-id>-<span-id>-<flags>`).
+pub fn extract_from_headers<H, F>(headers: &H, chain: &[&str], get: F) -> Option<String>
+where
+    F: Fn(&H, &str) -> Option<String>,
+{
+    for &name in chain {
+        if let Some(value) = get(headers, name) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if name.eq_ignore_ascii_case("traceparent") {
+                if let Some(trace_id) = parse_traceparent_trace_id(trimmed) {
+                    return Some(trace_id.to_owned());
+                }
+                continue;
+            }
+            return Some(trimmed.to_owned());
+        }
+    }
+    None
+}
+
+/// Parse the trace-id segment from a W3C `traceparent` header.
+///
+/// Format: `<version>-<trace-id>-<parent-id>-<trace-flags>`. Returns the
+/// trace-id segment if present and well-formed-enough to use as an id.
+#[must_use]
+pub fn parse_traceparent_trace_id(traceparent: &str) -> Option<&str> {
+    let mut parts = traceparent.split('-');
+    let _version = parts.next()?;
+    let trace_id = parts.next()?;
+    if trace_id.len() != 32 || !trace_id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(trace_id)
+}
+
+/// Run a synchronous closure inside a span carrying `correlation_id`.
+///
+/// ```
+/// # use kamu_logging::correlation::with_id;
+/// with_id("req-abc123", || {
+///     tracing::info!("inside correlation span");
+/// });
+/// ```
+pub fn with_id<F, R>(id: impl Into<String>, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let id = id.into();
+    let span = tracing::info_span!("correlation", correlation_id = %id);
+    let _enter = span.enter();
+    f()
+}
+
+/// Build a span carrying `correlation_id`. Useful when the caller wants to
+/// control entry/exit explicitly or attach to a future via
+/// [`tracing::Instrument`].
+#[must_use]
+pub fn span(id: impl AsRef<str>) -> tracing::Span {
+    tracing::info_span!("correlation", correlation_id = %id.as_ref())
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,236 @@
+//! Subscriber construction.
+
+use crate::{Error, InitOptions};
+
+#[cfg(feature = "systemd")]
+use std::sync::OnceLock;
+
+#[cfg(feature = "systemd")]
+static SUBSCRIBER_SET: OnceLock<()> = OnceLock::new();
+
+#[cfg(feature = "wasm32")]
+static WASM32_LOG_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
+/// Initialize the global tracing subscriber with default options.
+///
+/// Equivalent to `init_with(InitOptions::default())`.
+///
+/// # Errors
+///
+/// Returns [`Error::AlreadyInitialized`] if a subscriber is already set
+/// (use [`init_or_skip`] or [`InitOptions::idempotent`] for test harnesses).
+pub fn init() -> Result<(), Error> {
+    init_with(InitOptions::default())
+}
+
+/// Initialize the global tracing subscriber, returning `Ok(())` if a
+/// subscriber is already set.
+///
+/// Equivalent to `init_with(InitOptions::default().idempotent(true))`.
+///
+/// # Errors
+///
+/// Returns an error only on first-call failures unrelated to duplicate init
+/// (e.g. systemd `LogTracer` setup failure).
+pub fn init_or_skip() -> Result<(), Error> {
+    init_with(InitOptions::default().idempotent(true))
+}
+
+/// Initialize the global tracing subscriber from explicit options.
+///
+/// Env-var overrides applied when fields are at their default `Auto` value:
+///
+/// - `KAMU_LOG_FORMAT` — `auto`, `compact`, `pretty`, `json`
+/// - `KAMU_LOG_SINK` — `auto`, `stdout`, `stderr`, `journald`
+///
+/// # Errors
+///
+/// - [`Error::AlreadyInitialized`] if `idempotent` is `false` and a
+///   subscriber is already set.
+/// - [`Error::TracingGlobal`] / [`Error::TracingLog`] on subscriber setup
+///   failure.
+/// - [`Error::IO`] if the journald socket is unavailable.
+/// - [`Error::OtlpInit`] (with-otlp feature) if the exporter cannot be built.
+pub fn init_with(options: InitOptions) -> Result<(), Error> {
+    #[cfg(feature = "systemd")]
+    {
+        init_systemd(options)?;
+    }
+    #[cfg(feature = "wasm32")]
+    {
+        let _ = options;
+        init_wasm32();
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "systemd")]
+fn init_systemd(options: InitOptions) -> Result<(), Error> {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    if SUBSCRIBER_SET.get().is_some() {
+        return if options.idempotent {
+            Ok(())
+        } else {
+            Err(Error::AlreadyInitialized)
+        };
+    }
+
+    if let Err(err) = tracing_log::LogTracer::init() {
+        if !options.idempotent {
+            return Err(Error::from(err));
+        }
+    }
+
+    let env_var = options.resolved_env_var().to_owned();
+    let default_filter = options.resolved_default_filter().to_owned();
+    let filter_layer = tracing_subscriber::EnvFilter::try_from_env(&env_var)
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&default_filter));
+
+    let is_tty = console::Term::stdout().is_term();
+    let effective_sink = resolve_sink(options.sink, is_tty);
+    let effective_format = resolve_format(options.format, effective_sink, is_tty);
+
+    let output_layer = build_output_layer(effective_sink, effective_format, is_tty)?;
+
+    #[cfg(feature = "with-otlp")]
+    let otlp_layer = match options.otlp.as_ref() {
+        Some(cfg) => Some(crate::otlp::build_layer(cfg)?),
+        None => None,
+    };
+
+    let subscriber = tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(output_layer);
+
+    #[cfg(feature = "with-otlp")]
+    let subscriber = subscriber.with(otlp_layer);
+
+    tracing::subscriber::set_global_default(subscriber)?;
+    let _ = SUBSCRIBER_SET.set(());
+
+    if let Some(name) = options.service_name.as_deref() {
+        tracing::info!(service.name = %name, "Logging initialized");
+    } else {
+        tracing::info!("Logging initialized");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "systemd")]
+fn resolve_format(format: crate::Format, sink: crate::Sink, is_tty: bool) -> crate::Format {
+    use crate::{Format, Sink};
+
+    let mut effective = format;
+    if effective == Format::Auto {
+        if let Ok(value) = std::env::var("KAMU_LOG_FORMAT") {
+            effective = Format::from_env_value(&value);
+        }
+    }
+    if effective != Format::Auto {
+        return effective;
+    }
+    match sink {
+        Sink::Journald => Format::Compact,
+        Sink::Stdout | Sink::Stderr if is_tty => Format::Pretty,
+        Sink::Stdout | Sink::Stderr => Format::Compact,
+        Sink::Auto => Format::Compact,
+    }
+}
+
+#[cfg(feature = "systemd")]
+fn resolve_sink(sink: crate::Sink, is_tty: bool) -> crate::Sink {
+    use crate::Sink;
+
+    let mut effective = sink;
+    if effective == Sink::Auto {
+        if let Ok(value) = std::env::var("KAMU_LOG_SINK") {
+            effective = Sink::from_env_value(&value);
+        }
+    }
+    if effective != Sink::Auto {
+        return effective;
+    }
+    if is_tty { Sink::Stdout } else { Sink::Journald }
+}
+
+#[cfg(feature = "systemd")]
+type DynLayer = Box<
+    dyn tracing_subscriber::Layer<
+            tracing_subscriber::layer::Layered<
+                tracing_subscriber::EnvFilter,
+                tracing_subscriber::Registry,
+            >,
+        > + Send
+        + Sync,
+>;
+
+#[cfg(feature = "systemd")]
+fn build_output_layer(
+    sink: crate::Sink,
+    format: crate::Format,
+    is_tty: bool,
+) -> Result<DynLayer, Error> {
+    use crate::{Format, Sink};
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::fmt;
+
+    if sink == Sink::Journald {
+        let layer = tracing_journald::layer()?;
+        return Ok(Box::new(layer));
+    }
+
+    let writer: fmt::writer::BoxMakeWriter = match sink {
+        Sink::Stderr => fmt::writer::BoxMakeWriter::new(std::io::stderr),
+        _ => fmt::writer::BoxMakeWriter::new(std::io::stdout),
+    };
+
+    let span_events = fmt::format::FmtSpan::CLOSE;
+    let with_ansi = is_tty && format != Format::Json;
+
+    let layer: DynLayer = match format {
+        Format::Json => Box::new(
+            fmt::layer()
+                .with_writer(writer)
+                .with_span_events(span_events)
+                .with_line_number(true)
+                .with_thread_ids(true)
+                .json()
+                .with_current_span(true)
+                .with_span_list(false)
+                .boxed(),
+        ),
+        Format::Pretty => Box::new(
+            fmt::layer()
+                .with_writer(writer)
+                .with_span_events(span_events)
+                .with_ansi(with_ansi)
+                .with_line_number(true)
+                .with_thread_ids(true)
+                .pretty()
+                .boxed(),
+        ),
+        Format::Compact | Format::Auto => Box::new(
+            fmt::layer()
+                .with_writer(writer)
+                .with_span_events(span_events)
+                .with_ansi(with_ansi)
+                .with_line_number(true)
+                .with_thread_ids(true)
+                .compact()
+                .boxed(),
+        ),
+    };
+
+    Ok(layer)
+}
+
+#[cfg(feature = "wasm32")]
+fn init_wasm32() {
+    let _ = WASM32_LOG_INIT.get_or_init(|| {
+        console_error_panic_hook::set_once();
+        let _ = wasm_tracing::try_set_as_global_default();
+        tracing::info!("Logging initialized");
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,100 +1,74 @@
+//! `kamu-logging` — opinionated `tracing` setup for PT IMMER services.
+//!
+//! Call [`init`] from `main` for the zero-config path, or [`init_with`] with
+//! an [`InitOptions`] builder for explicit format / sink / filter / OTLP
+//! configuration. See the crate README for worked examples.
+//!
+//! Re-exports common `tracing` items so consumers can avoid a separate
+//! `tracing` import for the basic logging vocabulary.
+
+#![deny(missing_docs)]
+
 #[cfg(all(feature = "systemd", feature = "wasm32"))]
 compile_error!("Feature \"systemd\" can't be combined with \"wasm32\".");
 
 #[cfg(all(feature = "with-actix-web", feature = "wasm32"))]
 compile_error!("Feature \"with-actix-web\" can't be combined with \"wasm32\".");
 
+#[cfg(all(feature = "with-otlp", feature = "wasm32"))]
+compile_error!("Feature \"with-otlp\" can't be combined with \"wasm32\".");
+
 #[cfg(not(any(feature = "systemd", feature = "wasm32")))]
 compile_error!("At least feature \"systemd\" or \"wasm32\" must be enabled.");
 
-/// basic re-exports
-pub use tracing::{debug, error, info, trace, warn};
+pub mod correlation;
 
-#[cfg(all(debug_assertions, feature = "systemd"))]
-const TRACING_FILTER: &str = "debug";
-#[cfg(all(not(debug_assertions), feature = "systemd"))]
-const TRACING_FILTER: &str = "info";
-
-#[cfg(feature = "wasm32")]
-static WASM32_LOG_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-
-#[cfg(feature = "wasm32")]
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("{0}")]
-    IO(#[from] std::io::Error),
-    #[error("{0}")]
-    TracingGlobal(#[from] tracing::subscriber::SetGlobalDefaultError),
-}
-
-#[cfg(feature = "systemd")]
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("{0}")]
-    IO(#[from] std::io::Error),
-    #[error("{0}")]
-    TracingGlobal(#[from] tracing::subscriber::SetGlobalDefaultError),
-    #[error("{0}")]
-    TracingLog(#[from] tracing_log::log::SetLoggerError),
-}
-
-/// Initialize global tracing/logging subscriber.
-///
-/// # Errors
-///
-/// Returns an error if systemd logging setup fails or a global logger/subscriber is already set.
-pub fn init() -> std::result::Result<(), Error> {
-    #[cfg(feature = "systemd")]
-    init_systemd()?;
-    #[cfg(feature = "wasm32")]
-    init_wasm32();
-
-    tracing::info!("Logging initialized");
-
-    Ok(())
-}
-
-#[cfg(feature = "systemd")]
-fn init_systemd() -> std::result::Result<(), Error> {
-    tracing_log::LogTracer::init()?;
-    let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(TRACING_FILTER));
-    let subscriber = tracing_subscriber::layer::SubscriberExt::with(
-        tracing_subscriber::registry(),
-        filter_layer,
-    );
-
-    if console::Term::stdout().is_term() {
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
-            .with_ansi(true)
-            .with_line_number(true)
-            .with_thread_ids(true);
-        tracing::subscriber::set_global_default(tracing_subscriber::layer::SubscriberExt::with(
-            subscriber, fmt_layer,
-        ))?;
-    } else {
-        let journald_layer = tracing_journald::layer()?;
-        tracing::subscriber::set_global_default(tracing_subscriber::layer::SubscriberExt::with(
-            subscriber,
-            journald_layer,
-        ))?;
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "wasm32")]
-fn init_wasm32() {
-    let _ = WASM32_LOG_INIT.get_or_init(|| {
-        console_error_panic_hook::set_once();
-        let _ = wasm_tracing::try_set_as_global_default();
-    });
-}
+mod init;
+mod options;
 
 #[cfg(feature = "with-actix-web")]
-#[must_use]
-pub fn get_actix_web_logger()
--> tracing_actix_web::TracingLogger<tracing_actix_web::DefaultRootSpanBuilder> {
-    tracing_actix_web::TracingLogger::default()
+mod actix;
+
+#[cfg(feature = "with-otlp")]
+pub mod otlp;
+
+pub use crate::init::{init, init_or_skip, init_with};
+pub use crate::options::{Format, InitOptions, Sink};
+
+#[cfg(feature = "with-actix-web")]
+pub use crate::actix::{EnrichedRootSpanBuilder, get_actix_web_logger, get_actix_web_logger_with};
+
+/// Re-exports of the common `tracing` vocabulary so consumers can
+/// `use kamu_logging::{info, instrument, ...}` without a separate import.
+pub use tracing::{
+    Level, Span, debug, enabled, error, event, info, instrument, span, trace, warn,
+};
+
+/// Errors returned by [`init`] / [`init_with`].
+///
+/// Marked `#[non_exhaustive]` so future variants are not breaking changes.
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// I/O failure during subscriber setup (typically the journald socket).
+    #[error("{0}")]
+    IO(#[from] std::io::Error),
+
+    /// A subscriber is already set and `idempotent` was `false`.
+    #[error("logging subscriber already initialized")]
+    AlreadyInitialized,
+
+    /// `tracing::subscriber::set_global_default` failed.
+    #[error("{0}")]
+    TracingGlobal(#[from] tracing::subscriber::SetGlobalDefaultError),
+
+    /// `log::set_logger` failed (the `log` → `tracing` bridge).
+    #[cfg(feature = "systemd")]
+    #[error("{0}")]
+    TracingLog(#[from] tracing_log::log::SetLoggerError),
+
+    /// OTLP exporter construction failed.
+    #[cfg(feature = "with-otlp")]
+    #[error("OTLP init failed: {0}")]
+    OtlpInit(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,7 @@ pub use crate::actix::{EnrichedRootSpanBuilder, get_actix_web_logger, get_actix_
 
 /// Re-exports of the common `tracing` vocabulary so consumers can
 /// `use kamu_logging::{info, instrument, ...}` without a separate import.
-pub use tracing::{
-    Level, Span, debug, enabled, error, event, info, instrument, span, trace, warn,
-};
+pub use tracing::{Level, Span, debug, enabled, error, event, info, instrument, span, trace, warn};
 
 /// Errors returned by [`init`] / [`init_with`].
 ///

--- a/src/options.rs
+++ b/src/options.rs
@@ -166,6 +166,10 @@ impl InitOptions {
         if let Some(filter) = self.default_filter.as_deref() {
             return filter;
         }
-        if cfg!(debug_assertions) { "debug" } else { "info" }
+        if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "info"
+        }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,171 @@
+//! Configuration for [`init_with`](crate::init_with).
+
+/// Output format for the fmt layer.
+///
+/// `Auto` is replaced at init time by [`Format::Pretty`] when the chosen sink
+/// is a TTY and [`Format::Compact`] otherwise. Set the `KAMU_LOG_FORMAT`
+/// environment variable (`auto`, `compact`, `pretty`, `json`) to override
+/// without code changes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Format {
+    /// Resolved at init time based on sink + env var.
+    #[default]
+    Auto,
+    /// Single-line, machine-readable text format.
+    Compact,
+    /// Multi-line, human-readable text format with ANSI colors.
+    Pretty,
+    /// Line-delimited JSON. Required for log aggregators (Vector, Promtail,
+    /// Datadog Agent, Fluent Bit).
+    Json,
+}
+
+impl Format {
+    /// Parse from an env-var value. Unknown values resolve to `Auto`.
+    #[must_use]
+    pub fn from_env_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "compact" => Self::Compact,
+            "pretty" => Self::Pretty,
+            "json" => Self::Json,
+            _ => Self::Auto,
+        }
+    }
+}
+
+/// Where to write log events.
+///
+/// `Auto` (default) emits to the console when stdout is a TTY and to journald
+/// otherwise. Set `KAMU_LOG_SINK` (`auto`, `stdout`, `stderr`, `journald`) to
+/// override without code changes. `Journald` is rejected on targets without
+/// the `systemd` feature.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Sink {
+    /// TTY → console, non-TTY → journald (on systemd) or stderr (otherwise).
+    #[default]
+    Auto,
+    /// Write to stdout.
+    Stdout,
+    /// Write to stderr.
+    Stderr,
+    /// Write to the systemd journal. Requires the `systemd` feature.
+    Journald,
+}
+
+impl Sink {
+    /// Parse from an env-var value. Unknown values resolve to `Auto`.
+    #[must_use]
+    pub fn from_env_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "stdout" => Self::Stdout,
+            "stderr" => Self::Stderr,
+            "journald" => Self::Journald,
+            _ => Self::Auto,
+        }
+    }
+}
+
+/// Configuration for [`init_with`](crate::init_with).
+///
+/// Constructed via [`InitOptions::default`] and the `with_*` builder methods.
+/// Each method consumes `self` and returns `Self` to support chaining:
+///
+/// ```no_run
+/// use kamu_logging::{init_with, Format, InitOptions, Sink};
+///
+/// init_with(
+///     InitOptions::default()
+///         .with_service_name("my-service")
+///         .with_format(Format::Json)
+///         .with_sink(Sink::Stdout),
+/// )?;
+/// # Ok::<(), kamu_logging::Error>(())
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct InitOptions {
+    pub(crate) service_name: Option<String>,
+    pub(crate) default_filter: Option<String>,
+    pub(crate) env_var: Option<String>,
+    pub(crate) format: Format,
+    pub(crate) sink: Sink,
+    pub(crate) idempotent: bool,
+    #[cfg(feature = "with-otlp")]
+    pub(crate) otlp: Option<crate::otlp::OtlpConfig>,
+}
+
+impl InitOptions {
+    /// Attach a `service.name` field to every event. Used by log aggregators
+    /// to route logs across services.
+    #[must_use]
+    pub fn with_service_name(mut self, name: impl Into<String>) -> Self {
+        self.service_name = Some(name.into());
+        self
+    }
+
+    /// Default filter directive when the env var is unset. Defaults to
+    /// `"debug"` in debug builds and `"info"` in release builds.
+    #[must_use]
+    pub fn with_default_filter(mut self, filter: impl Into<String>) -> Self {
+        self.default_filter = Some(filter.into());
+        self
+    }
+
+    /// Environment variable read for the filter directive. Defaults to
+    /// `"RUST_LOG"`. Useful for per-binary triggers like `"KKP_LOG"` to avoid
+    /// collisions with other tools' `RUST_LOG` settings.
+    #[must_use]
+    pub fn with_env_var(mut self, var: impl Into<String>) -> Self {
+        self.env_var = Some(var.into());
+        self
+    }
+
+    /// Output format. See [`Format`].
+    #[must_use]
+    pub fn with_format(mut self, format: Format) -> Self {
+        self.format = format;
+        self
+    }
+
+    /// Output sink. See [`Sink`].
+    #[must_use]
+    pub fn with_sink(mut self, sink: Sink) -> Self {
+        self.sink = sink;
+        self
+    }
+
+    /// When `true`, a second [`init_with`](crate::init_with) call returns
+    /// `Ok(())` instead of [`Error::TracingGlobal`](crate::Error::TracingGlobal).
+    ///
+    /// Default is `false` so library double-init surfaces as an error. Set
+    /// `true` from test harnesses and embedded CLI runs where re-init is
+    /// expected.
+    #[must_use]
+    pub fn idempotent(mut self, enabled: bool) -> Self {
+        self.idempotent = enabled;
+        self
+    }
+
+    /// Attach an OpenTelemetry OTLP exporter layer. Requires the `with-otlp`
+    /// feature.
+    #[cfg(feature = "with-otlp")]
+    #[must_use]
+    pub fn with_otlp(mut self, config: crate::otlp::OtlpConfig) -> Self {
+        self.otlp = Some(config);
+        self
+    }
+
+    #[cfg(feature = "systemd")]
+    pub(crate) fn resolved_env_var(&self) -> &str {
+        self.env_var.as_deref().unwrap_or("RUST_LOG")
+    }
+
+    #[cfg(feature = "systemd")]
+    pub(crate) fn resolved_default_filter(&self) -> &str {
+        if let Some(filter) = self.default_filter.as_deref() {
+            return filter;
+        }
+        if cfg!(debug_assertions) { "debug" } else { "info" }
+    }
+}

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -1,0 +1,106 @@
+//! OpenTelemetry OTLP exporter wiring.
+//!
+//! Enabled by the `with-otlp` feature. Adds a [`tracing_opentelemetry`]
+//! layer to the subscriber stack that exports spans to an OTLP collector
+//! over HTTP/protobuf.
+//!
+//! Uses a synchronous `SimpleSpanProcessor` so no async runtime is required
+//! by this crate. High-throughput services should replace the layer with a
+//! batch processor configured against their runtime.
+
+use std::collections::HashMap;
+
+use opentelemetry::KeyValue;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+
+/// Configuration for the OTLP exporter.
+#[derive(Debug, Clone)]
+pub struct OtlpConfig {
+    pub(crate) endpoint: String,
+    pub(crate) service_name: Option<String>,
+    pub(crate) headers: HashMap<String, String>,
+    pub(crate) resource_attributes: Vec<(String, String)>,
+}
+
+impl OtlpConfig {
+    /// Endpoint for the OTLP/HTTP collector, e.g.
+    /// `https://otel-collector.example.com:4318`.
+    #[must_use]
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            service_name: None,
+            headers: HashMap::new(),
+            resource_attributes: Vec::new(),
+        }
+    }
+
+    /// Set `service.name` on the resource. Most collectors require this for
+    /// per-service routing/quotas.
+    #[must_use]
+    pub fn with_service_name(mut self, name: impl Into<String>) -> Self {
+        self.service_name = Some(name.into());
+        self
+    }
+
+    /// Add an HTTP header sent on every export request (e.g. auth tokens).
+    #[must_use]
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(key.into(), value.into());
+        self
+    }
+
+    /// Add an arbitrary resource attribute (e.g. `deployment.environment`).
+    #[must_use]
+    pub fn with_resource_attribute(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.resource_attributes.push((key.into(), value.into()));
+        self
+    }
+}
+
+pub(crate) fn build_layer<S>(
+    config: &OtlpConfig,
+) -> Result<
+    tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>,
+    crate::Error,
+>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let mut builder = SpanExporter::builder()
+        .with_http()
+        .with_endpoint(&config.endpoint);
+
+    if !config.headers.is_empty() {
+        builder = builder.with_headers(config.headers.clone());
+    }
+
+    let exporter = builder
+        .build()
+        .map_err(|e| crate::Error::OtlpInit(e.to_string()))?;
+
+    let mut attrs: Vec<KeyValue> = config
+        .resource_attributes
+        .iter()
+        .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+        .collect();
+    if let Some(name) = config.service_name.as_deref() {
+        attrs.push(KeyValue::new("service.name", name.to_owned()));
+    }
+
+    let resource = Resource::builder().with_attributes(attrs).build();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    let tracer = provider.tracer("kamu-logging");
+    Ok(tracing_opentelemetry::layer().with_tracer(tracer))
+}

--- a/tests/correlation.rs
+++ b/tests/correlation.rs
@@ -1,0 +1,75 @@
+//! Header-chain extraction round-trips for [`kamu_logging::correlation`].
+
+use std::collections::HashMap;
+
+use kamu_logging::correlation::{
+    DEFAULT_HEADER_CHAIN, extract_from_headers, parse_traceparent_trace_id,
+};
+
+fn get(map: &HashMap<&str, &str>, name: &str) -> Option<String> {
+    let lower = name.to_ascii_lowercase();
+    map.iter()
+        .find(|(k, _)| k.to_ascii_lowercase() == lower)
+        .map(|(_, v)| (*v).to_owned())
+}
+
+#[test]
+fn missing_headers_yields_none() {
+    let headers: HashMap<&str, &str> = HashMap::new();
+    assert!(extract_from_headers(&headers, DEFAULT_HEADER_CHAIN, get).is_none());
+}
+
+#[test]
+fn x_request_id_wins_over_x_correlation_id() {
+    let mut headers = HashMap::new();
+    headers.insert("X-Request-ID", "req-abc");
+    headers.insert("X-Correlation-ID", "corr-xyz");
+    let id = extract_from_headers(&headers, DEFAULT_HEADER_CHAIN, get);
+    assert_eq!(id.as_deref(), Some("req-abc"));
+}
+
+#[test]
+fn x_correlation_id_used_when_x_request_id_missing() {
+    let mut headers = HashMap::new();
+    headers.insert("X-Correlation-ID", "corr-xyz");
+    let id = extract_from_headers(&headers, DEFAULT_HEADER_CHAIN, get);
+    assert_eq!(id.as_deref(), Some("corr-xyz"));
+}
+
+#[test]
+fn empty_header_value_is_skipped() {
+    let mut headers = HashMap::new();
+    headers.insert("X-Request-ID", "   ");
+    headers.insert("X-Correlation-ID", "corr-xyz");
+    let id = extract_from_headers(&headers, DEFAULT_HEADER_CHAIN, get);
+    assert_eq!(id.as_deref(), Some("corr-xyz"));
+}
+
+#[test]
+fn traceparent_falls_back_to_trace_id_segment() {
+    let mut headers = HashMap::new();
+    headers.insert(
+        "traceparent",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    );
+    let id = extract_from_headers(&headers, DEFAULT_HEADER_CHAIN, get);
+    assert_eq!(id.as_deref(), Some("4bf92f3577b34da6a3ce929d0e0e4736"));
+}
+
+#[test]
+fn malformed_traceparent_yields_none() {
+    let mut headers = HashMap::new();
+    headers.insert("traceparent", "not-a-traceparent");
+    let id = extract_from_headers(&headers, DEFAULT_HEADER_CHAIN, get);
+    assert!(id.is_none());
+}
+
+#[test]
+fn parse_traceparent_rejects_short_trace_id() {
+    assert!(parse_traceparent_trace_id("00-deadbeef-spanid-01").is_none());
+}
+
+#[test]
+fn parse_traceparent_rejects_non_hex() {
+    assert!(parse_traceparent_trace_id("00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-aaaaaaaaaaaaaaaa-01").is_none());
+}

--- a/tests/correlation.rs
+++ b/tests/correlation.rs
@@ -71,5 +71,8 @@ fn parse_traceparent_rejects_short_trace_id() {
 
 #[test]
 fn parse_traceparent_rejects_non_hex() {
-    assert!(parse_traceparent_trace_id("00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-aaaaaaaaaaaaaaaa-01").is_none());
+    assert!(
+        parse_traceparent_trace_id("00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-aaaaaaaaaaaaaaaa-01")
+            .is_none()
+    );
 }

--- a/tests/init_idempotent.rs
+++ b/tests/init_idempotent.rs
@@ -1,0 +1,11 @@
+//! `InitOptions::idempotent(true)` matches `init_or_skip()` semantics.
+
+#![cfg(feature = "systemd")]
+
+use kamu_logging::{InitOptions, init_with};
+
+#[test]
+fn idempotent_option_allows_double_init() {
+    init_with(InitOptions::default().idempotent(true)).expect("first init succeeds");
+    init_with(InitOptions::default().idempotent(true)).expect("second init succeeds");
+}

--- a/tests/init_or_skip.rs
+++ b/tests/init_or_skip.rs
@@ -1,0 +1,11 @@
+//! `init_or_skip()` must succeed on a second call.
+
+#![cfg(feature = "systemd")]
+
+use kamu_logging::init_or_skip;
+
+#[test]
+fn second_init_or_skip_returns_ok() {
+    init_or_skip().expect("first init_or_skip succeeds");
+    init_or_skip().expect("second init_or_skip must also succeed");
+}

--- a/tests/init_strict.rs
+++ b/tests/init_strict.rs
@@ -1,0 +1,15 @@
+//! `init()` must error on a second call.
+
+#![cfg(feature = "systemd")]
+
+use kamu_logging::{Error, init};
+
+#[test]
+fn second_init_returns_already_initialized() {
+    init().expect("first init succeeds");
+    let err = init().expect_err("second init must fail");
+    assert!(
+        matches!(err, Error::AlreadyInitialized),
+        "expected AlreadyInitialized, got {err:?}",
+    );
+}


### PR DESCRIPTION
This pull request prepares the project for its 1.0.0 release, introducing major new features, a rewritten and expanded README, a detailed changelog, and comprehensive CI/CD automation. The highlights include a new builder-based logging configuration, JSON and OTLP support, correlation ID extraction, improved Actix Web integration, and robust CI workflows for formatting, linting, testing, and publishing.

**Major new features and breaking changes:**

* Introduced a builder-based configuration (`InitOptions`) for logging setup, with support for explicit format and sink selection, service tagging, idempotence, and OTLP export via a new `with-otlp` feature. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R85) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L13-R29) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R39-R43)
* Added correlation ID extraction utilities and enriched Actix Web middleware with automatic correlation ID propagation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R85) [[2]](diffhunk://#diff-f5b68199cd61501af485ef6f697dac10adf77f7c1d72154dcca51e82bc77b659R1-R23)
* Breaking: Changed error handling for duplicate initialization (`init()` now returns `Error::AlreadyInitialized`), and changed the default Actix Web logger to use the enriched root span builder.
* Expanded `tracing` re-exports and improved documentation coverage and policy. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R85) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R202)

**Documentation and examples:**

* Rewrote `README.md` to document all new features, configuration options, environment variable triggers, OTLP setup, correlation handling, and troubleshooting.
* Added a comprehensive `CHANGELOG.md` following Keep a Changelog and SemVer conventions.
* Added new examples, including an Actix Web example with correlation ID enrichment. [[1]](diffhunk://#diff-f5b68199cd61501af485ef6f697dac10adf77f7c1d72154dcca51e82bc77b659R1-R23) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R62-R77)

**CI/CD and workflow automation:**

* Added a full GitHub Actions workflow for formatting, linting (Rust and Markdown), testing (multiple profiles), MSRV checks, documentation, code coverage, auditing, and semver checks.
* Added a publish workflow for verifying and releasing to crates.io, including version tag checks and multi-feature builds.
* Added a markdownlint configuration for consistent documentation style.

**Cargo manifest and dependencies:**

* Declared MSRV (`rust-version = "1.85"`) and updated to version 1.0.0.
* Added new dependencies for Actix Web and OTLP support, and updated example targets and required features. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L13-R29) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R39-R43) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R62-R77)

**References:**  
[[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R85) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R202) [[3]](diffhunk://#diff-f5b68199cd61501af485ef6f697dac10adf77f7c1d72154dcca51e82bc77b659R1-R23) [[4]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160R1-R198) [[5]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R71) [[6]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L13-R29) [[7]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R39-R43) [[8]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R62-R77) [[9]](diffhunk://#diff-2a7fead57f7c323860561f88108bea9da390f1fcccc08278680b62b0ff6e1d5bR1-R21)