### PR TITLE
fix(lint): exclude CLAUDE.md from markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -19,3 +19,5 @@ ignores:
   - "target/**"
   - "node_modules/**"
   - ".github/**"
+  # Local agent-instruction file; not a distributable doc.
+  - "CLAUDE.md"


### PR DESCRIPTION
## Summary
- `just gate-all` was failing at `lint-md` with 47 errors on `CLAUDE.md` (MD007/MD030/MD032/MD055/MD056/MD058).
- `CLAUDE.md` is a local agent-instruction file tuned for LLM consumption (compact 2-col tables, 2-space-indented sub-lists). The compact form is the point — fixing the markdown would defeat the purpose.
- Added `CLAUDE.md` to `.markdownlint-cli2.yaml` `ignores:` list. `just gate-all` now green.

## Test plan
- [x] `just lint-md` → 0 errors, 3 files linted (CLAUDE.md skipped)
- [x] `just gate-all` → all stages pass (fmt-check, clippy, clippy-wasm, lint-md, test-all, validate-wasm32, doc-check, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)